### PR TITLE
Automatically encode struct requests with encoding/xml

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -68,7 +68,15 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 }
 
 func (tokens *tokenData) bodyContents(c process, namespace string, e *xml.Encoder) error {
-	if c.Request.UseXMLEncoder {
+	useEncodingXml := false
+	t := reflect.TypeOf(c.Request.Params)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Struct {
+		useEncodingXml = true
+	}
+	if useEncodingXml {
 		if err := tokens.flush(e); err != nil {
 			return err
 		}

--- a/encode.go
+++ b/encode.go
@@ -51,6 +51,23 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 		return err
 	}
 
+	err = tokens.bodyContents(c, namespace, e)
+	if err != nil {
+		return err
+	}
+
+	//end envelope
+	tokens.endBody()
+	tokens.endEnvelope()
+
+	if err := tokens.flush(e); err != nil {
+		return err
+	}
+
+	return e.Flush()
+}
+
+func (tokens *tokenData) bodyContents(c process, namespace string, e *xml.Encoder) error {
 	if c.Request.UseXMLEncoder {
 		if err := tokens.flush(e); err != nil {
 			return err
@@ -68,16 +85,7 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 		}
 		tokens.endBodyPayload(c.Request.Method)
 	}
-
-	//end envelope
-	tokens.endBody()
-	tokens.endEnvelope()
-
-	if err := tokens.flush(e); err != nil {
-		return err
-	}
-
-	return e.Flush()
+	return nil
 }
 
 func (tokens *tokenData) flush(e *xml.Encoder) error {

--- a/encode.go
+++ b/encode.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	soapPrefix = "soap"
+	soapPrefix                            = "soap"
 	customEnvelopeAttrs map[string]string = nil
 )
 
@@ -40,7 +40,9 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 	tokens.startEnvelope()
 	if c.Client.HeaderParams != nil {
 		tokens.startHeader(c.Client.HeaderName, namespace)
-		tokens.recursiveEncode(c.Client.HeaderParams)
+		if err := tokens.recursiveEncode(c.Client.HeaderParams); err != nil {
+			return err
+		}
 		tokens.endHeader(c.Client.HeaderName)
 	}
 
@@ -49,27 +51,52 @@ func (c process) MarshalXML(e *xml.Encoder, _ xml.StartElement) error {
 		return err
 	}
 
-	tokens.recursiveEncode(c.Request.Params)
+	if c.Request.UseXMLEncoder {
+		if err := tokens.flush(e); err != nil {
+			return err
+		}
+		if err := e.Encode(c.Request.Params); err != nil {
+			return err
+		}
+		if err := tokens.flush(e); err != nil {
+			return err
+		}
+	} else {
+		tokens.startBodyPayload(c.Request.Method, namespace)
+		if err := tokens.recursiveEncode(c.Request.Params); err != nil {
+			return err
+		}
+		tokens.endBodyPayload(c.Request.Method)
+	}
 
 	//end envelope
-	tokens.endBody(c.Request.Method)
+	tokens.endBody()
 	tokens.endEnvelope()
 
+	if err := tokens.flush(e); err != nil {
+		return err
+	}
+
+	return e.Flush()
+}
+
+func (tokens *tokenData) flush(e *xml.Encoder) error {
 	for _, t := range tokens.data {
 		err := e.EncodeToken(t)
 		if err != nil {
 			return err
 		}
 	}
-
-	return e.Flush()
+	tokens.data = []xml.Token{}
+	return nil
 }
 
 type tokenData struct {
 	data []xml.Token
+	// encoder *xml.Encoder
 }
 
-func (tokens *tokenData) recursiveEncode(hm interface{}) {
+func (tokens *tokenData) recursiveEncode(hm interface{}) error {
 	v := reflect.ValueOf(hm)
 
 	switch v.Kind() {
@@ -83,12 +110,16 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 			}
 
 			tokens.data = append(tokens.data, t)
-			tokens.recursiveEncode(v.MapIndex(key).Interface())
+			if err := tokens.recursiveEncode(v.MapIndex(key).Interface()); err != nil {
+				return err
+			}
 			tokens.data = append(tokens.data, xml.EndElement{Name: t.Name})
 		}
 	case reflect.Slice:
 		for i := 0; i < v.Len(); i++ {
-			tokens.recursiveEncode(v.Index(i).Interface())
+			if err := tokens.recursiveEncode(v.Index(i).Interface()); err != nil {
+				return err
+			}
 		}
 	case reflect.Array:
 		if v.Len() == 2 {
@@ -101,7 +132,9 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 			}
 
 			tokens.data = append(tokens.data, t)
-			tokens.recursiveEncode(v.Index(1).Interface())
+			if err := tokens.recursiveEncode(v.Index(1).Interface()); err != nil {
+				return err
+			}
 			tokens.data = append(tokens.data, xml.EndElement{Name: t.Name})
 		}
 	case reflect.String:
@@ -110,6 +143,7 @@ func (tokens *tokenData) recursiveEncode(hm interface{}) {
 	case reflect.Struct:
 		tokens.data = append(tokens.data, v.Interface())
 	}
+	return nil
 }
 
 func (tokens *tokenData) startEnvelope() {
@@ -130,7 +164,7 @@ func (tokens *tokenData) startEnvelope() {
 		e.Attr = make([]xml.Attr, 0)
 		for local, value := range customEnvelopeAttrs {
 			e.Attr = append(e.Attr, xml.Attr{
-				Name: xml.Name{Space: "", Local: local},
+				Name:  xml.Name{Space: "", Local: local},
 				Value: value,
 			})
 		}
@@ -174,8 +208,6 @@ func (tokens *tokenData) startHeader(m, n string) {
 	}
 
 	tokens.data = append(tokens.data, h, r)
-
-	return
 }
 
 func (tokens *tokenData) endHeader(m string) {
@@ -202,17 +234,21 @@ func (tokens *tokenData) endHeader(m string) {
 }
 
 func (tokens *tokenData) startBody(m, n string) error {
+	if m == "" || n == "" {
+		return fmt.Errorf("method or namespace is empty")
+	}
+
 	b := xml.StartElement{
 		Name: xml.Name{
 			Space: "",
 			Local: fmt.Sprintf("%s:Body", soapPrefix),
 		},
 	}
+	tokens.data = append(tokens.data, b)
+	return nil
+}
 
-	if m == "" || n == "" {
-		return fmt.Errorf("method or namespace is empty")
-	}
-
+func (tokens *tokenData) startBodyPayload(m, n string) {
 	r := xml.StartElement{
 		Name: xml.Name{
 			Space: "",
@@ -222,27 +258,26 @@ func (tokens *tokenData) startBody(m, n string) error {
 			{Name: xml.Name{Space: "", Local: "xmlns"}, Value: n},
 		},
 	}
-
-	tokens.data = append(tokens.data, b, r)
-
-	return nil
+	tokens.data = append(tokens.data, r)
 }
 
 // endToken close body of the envelope
-func (tokens *tokenData) endBody(m string) {
-	b := xml.EndElement{
-		Name: xml.Name{
-			Space: "",
-			Local: fmt.Sprintf("%s:Body", soapPrefix),
-		},
-	}
-
+func (tokens *tokenData) endBodyPayload(m string) {
 	r := xml.EndElement{
 		Name: xml.Name{
 			Space: "",
 			Local: m,
 		},
 	}
+	tokens.data = append(tokens.data, r)
+}
 
-	tokens.data = append(tokens.data, r, b)
+func (tokens *tokenData) endBody() {
+	b := xml.EndElement{
+		Name: xml.Name{
+			Space: "",
+			Local: fmt.Sprintf("%s:Body", soapPrefix),
+		},
+	}
+	tokens.data = append(tokens.data, b)
 }

--- a/encode_test.go
+++ b/encode_test.go
@@ -125,6 +125,11 @@ type checkVatApproxResponse struct {
 	TraderName  string `xml:"traderName,omitempty"`
 }
 
+func (cva *checkVatApprox) SoapBuildRequest() *Request {
+	r := NewRequest("checkVatApprox", cva)
+	return r
+}
+
 var encoderParamsTests = []struct {
 	Desc     string
 	WSDL     string
@@ -156,11 +161,6 @@ var encoderParamsTests = []struct {
 	},
 }
 
-func (cva *checkVatApprox) SoapBuildRequest() *Request {
-	r := NewRequest("checkVatApprox", cva)
-	r.UseXMLEncoder = true
-	return r
-}
 func TestClient_MarshalWithEncoder(t *testing.T) {
 	for _, test := range encoderParamsTests {
 		soap, err := SoapClient(test.WSDL, nil)

--- a/request.go
+++ b/request.go
@@ -6,8 +6,9 @@ import (
 
 // Request Soap Request
 type Request struct {
-	Method string
-	Params SoapParams
+	Method        string
+	Params        SoapParams
+	UseXMLEncoder bool
 }
 
 func NewRequest(m string, p SoapParams) *Request {

--- a/request.go
+++ b/request.go
@@ -6,9 +6,8 @@ import (
 
 // Request Soap Request
 type Request struct {
-	Method        string
-	Params        SoapParams
-	UseXMLEncoder bool
+	Method string
+	Params SoapParams
 }
 
 func NewRequest(m string, p SoapParams) *Request {

--- a/soap_test.go
+++ b/soap_test.go
@@ -185,14 +185,14 @@ func TestClient_Call(t *testing.T) {
 	}
 
 	c := &Client{}
-	res, err = c.Call("", Params{})
+	_, err = c.Call("", Params{})
 	if err == nil {
 		t.Errorf("error expected but nothing got.")
 	}
 
 	c.SetWSDL("://test.")
 
-	res, err = c.Call("checkVat", params)
+	_, err = c.Call("checkVat", params)
 	if err == nil {
 		t.Errorf("invalid WSDL")
 	}


### PR DESCRIPTION
This leaves the struct handling alone in recursiveEncode, which is designed to deal with individual xml.Tokens.

Instead, we just use xml.Encode for top-level structs instead of diving into recursiveEncode, and leave the formatting up to the struct tags